### PR TITLE
fix: make all rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,5 +67,8 @@ go.sum: go.mod
 		@echo "--> Ensure dependencies have not been modified"
 		@go mod verify
 
+lint:
+    golangci-lint run --out-format=tab
+
 build:
 	go build $(BUILD_FLAGS) -o ./build/kujirad ./cmd/kujirad


### PR DESCRIPTION
### Problem 
- `make all` not working due to missing rules for lint
### Solution
- I updated the makefile adding for lint, I just added the tab rule.  If you expect to add other cases I will update `.golangci.yml`. 

Let me know