### PR TITLE
Update Makefile - spaces to tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ go.sum: go.mod
 		@go mod verify
 
 lint:
-    golangci-lint run --out-format=tab
+	golangci-lint run --out-format=tab
 
 build:
 	go build $(BUILD_FLAGS) -o ./build/kujirad ./cmd/kujirad


### PR DESCRIPTION
Getting the following error when performing `make install`:

```Makefile:71: *** missing separator.  Stop.```

This change changes **spaces** to **tabs** and fixes the build issue