### PR TITLE
Add Go version enforcement in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,15 @@ BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 
 #### Command List ####
 
+check-go-version:
+	@if ! go version | grep -Eq "go1.19.[3-7]"; then \
+		echo "\033[0;31mERROR:\033[0m Go version 1.19.3 through 1.19.7 is required for compiling kujirad. Installed version:" "$(shell go version)"; \
+		exit 1; \
+	fi
+
 all: lint install
 
-install: go.sum
+install: check-go-version go.sum
 		go install $(BUILD_FLAGS) ./cmd/kujirad
 
 go.sum: go.mod
@@ -70,5 +76,5 @@ go.sum: go.mod
 lint:
 	golangci-lint run --out-format=tab
 
-build:
+build: check-go-version
 	go build $(BUILD_FLAGS) -o ./build/kujirad ./cmd/kujirad


### PR DESCRIPTION
This PR adds Go version enforcement when running `make build` or `make install`. 

This PR sets the acceptable Go versions to 1.19.3 through 1.19.7. This should be changed to enforce 1.20+ once v0.8.4 is implemented since the cosmos-sdk 0.47 bumps it to 1.20. This can also be modified to ignore patch version if desired.

Thanks [jasonsopko](https://github.com/jasonsopko) for the initial PR on Jackal that served as the basis for this PR (https://github.com/JackalLabs/canine-chain/pull/298).