### PR TITLE
switch to go.mod requiring 1.19 minimum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Team-Kujira/core
 
-go 1.18
+go 1.19
 
 require (
 	github.com/CosmWasm/wasmd v0.30.0


### PR DESCRIPTION
some automated tools use this to determine which go version they should build with.